### PR TITLE
Apply clippy suggestions

### DIFF
--- a/cli-rs/src/cfg.rs
+++ b/cli-rs/src/cfg.rs
@@ -6,7 +6,7 @@ pub struct CliConfig {
     pub example: String,
 }
 
-pub fn read_config<'a>(maybe_filename: &Option<&str>) -> Result<CliConfig, error::Error> {
+pub fn read_config(maybe_filename: &Option<&str>) -> Result<CliConfig, error::Error> {
     let settings = read_merged_config(maybe_filename).map_err(|_| error::Error::ReadConfigError)?;
     let example = settings
         .get_string("example")
@@ -19,17 +19,17 @@ pub fn read_merged_config(maybe_filename: &Option<&str>) -> Result<config::Confi
 
     settings = settings.add_source(File::new("conf/defaults", FileFormat::Yaml));
 
-    settings = match maybe_filename {
-        &Some(filename) => {
+    settings = match *maybe_filename {
+        Some(filename) => {
             if !Path::new(filename).exists() {
                 return Err(error::Error::ConfigFileDoesNotExistError(
                     filename.to_owned(),
                 ));
             } else {
-                settings.add_source(File::new(&filename, FileFormat::Yaml))
+                settings.add_source(File::new(filename, FileFormat::Yaml))
             }
         }
-        &None => settings,
+        None => settings,
     };
     settings = settings.add_source(config::Environment::with_prefix("app"));
 

--- a/cli-rs/src/constants.rs
+++ b/cli-rs/src/constants.rs
@@ -1,2 +1,2 @@
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-pub const AUTHORS: &'static str = env!("CARGO_PKG_AUTHORS");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -29,10 +29,7 @@ fn main() {
 ///
 /// * `config` - configuration
 fn configure_commands() -> Vec<impl Command> {
-    let mut commands = Vec::new();
-
-    commands.push(ctx_example::example_command());
-    commands
+    vec![ctx_example::example_command()]
 }
 
 fn init_log(matches: &ArgMatches) {
@@ -47,7 +44,7 @@ fn init_log(matches: &ArgMatches) {
     let loglevel = match matches.value_of("module") {
         Some(module) => {
             let mut module_loglevel = String::from(module);
-            module_loglevel.push_str("=");
+            module_loglevel.push('=');
             module_loglevel.push_str(loglevel);
             module_loglevel
         }
@@ -59,7 +56,7 @@ fn init_log(matches: &ArgMatches) {
     debug!("Setting log level to {}", &loglevel);
 }
 
-fn parse_cli(commands: &Vec<impl Command>) -> clap::ArgMatches {
+fn parse_cli(commands: &[impl Command]) -> clap::ArgMatches {
     let parser = clap::Command::new("{{crate_name}}")
         .version({{crate_name}}::version())
         .author({{crate_name}}::authors())
@@ -82,7 +79,7 @@ fn parse_cli(commands: &Vec<impl Command>) -> clap::ArgMatches {
             .help("Level of verbosity (error is default) if used multiple times: warn(v), info(vv), debug(vvv) and trace(vvvv)"));
 
     commands
-        .into_iter()
+        .iter()
         .fold(parser, |parser, cmd| parser.subcommand(cmd.cli()))
         .get_matches()
 }


### PR DESCRIPTION
This commits incorperates clippy suggestions into the template.
This then leads to no clippy warnings when invoking `cargo clippy` on
a freshly generated project